### PR TITLE
Change the default operator to raw

### DIFF
--- a/pkg/archiverappliance/operators.go
+++ b/pkg/archiverappliance/operators.go
@@ -76,7 +76,7 @@ func createOperatorQuery(qm models.ArchiverQueryModel) (string, error) {
 
 	opr := qm.Operator
 	if opr == "" {
-		opr = "mean"
+		opr = "raw"
 	}
 
 	var opBuilder strings.Builder


### PR DESCRIPTION
The default selection should probably be raw, with users electing to transform the data.